### PR TITLE
Change default port number to 52698

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A package that implements the Textmate's 'rmate' feature for VSCode.
   //-------- Remote VSCode configuration --------
 
   // Port number to use for connection.
-  "remote.port": 52689,
+  "remote.port": 52698,
 
   // Launch the server on start up.
   "remote.onstartup": true
@@ -37,12 +37,12 @@ A package that implements the Textmate's 'rmate' feature for VSCode.
 
 * Create an ssh tunnel
   ```bash
-  ssh -R 52689:127.0.0.1:52689 user@example.org
+  ssh -R 52698:127.0.0.1:52698 user@example.org
   ```
 
 * Go to the remote system and run
   ```bash
-  rmate -p 52689 file
+  rmate -p 52698 file
   ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
       "properties": {
         "remote.port": {
           "type": "number",
-          "default": 52689,
+          "default": 52698,
           "description": "Port number to use for connection."
         },
         "remote.onstartup": {

--- a/src/lib/Server.ts
+++ b/src/lib/Server.ts
@@ -5,7 +5,7 @@ import Logger from '../utils/Logger';
 
 const L = Logger.getLogger('Server');
 
-const DEFAULT_PORT = 52689;
+const DEFAULT_PORT = 52698;
 
 class Server {
   online : boolean = false;


### PR DESCRIPTION
Because all of the following use **52698** instead of **52689**:

 - Ruby version: https://github.com/textmate/rmate
 - Bash version: https://github.com/aurora/rmate
 - Perl version: https://github.com/davidolrik/rmate-perl
 - Python version: https://github.com/sclukey/rmate-python
 - Nim version: https://github.com/aurora/rmate-nim
 - C version: https://github.com/hanklords/rmate.c
 - Node.js version: https://github.com/jrnewell/jmate