### PR TITLE
Add the ability to edit the listening address.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "remote-vscode",
   "displayName": "Remote VSCode",
   "description": "A package that implements the Textmate's 'rmate' feature for VSCode.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "rafaelmaiolla",
   "license": "MIT",
   "author": "Rafael Maiolla <rafaelmaiolla@gmail.com>",
@@ -45,7 +45,12 @@
           "type": "boolean",
           "default": false,
           "description": "Launch the server on start up."
-        }
+        },
+        "remote.host": {
+          "type": "string",
+          "default": "127.0.0.1",
+          "description": "Address to listen on."
+        }        
       }
     },
     "commands": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,7 @@ const L = Logger.getLogger('extension');
 var server : Server;
 var changeConfigurationDisposable : vscode.Disposable;
 var port : number;
+var host : string;
 var onStartup : boolean;
 
 const startServer = () => {
@@ -18,6 +19,7 @@ const startServer = () => {
   }
 
   server.setPort(port);
+  server.setHost(host);
   server.start(false);
 };
 
@@ -35,6 +37,7 @@ const initialize = () => {
   var configuration = getConfiguration();
   onStartup = configuration.onStartup;
   port = configuration.port;
+  host = configuration.host;
 
   if (onStartup) {
     startServer();
@@ -47,7 +50,8 @@ const getConfiguration = () => {
 
   var configuration = {
     onStartup: remoteConfig.get<boolean>('onstartup'),
-    port: remoteConfig.get<number>('port')
+    port: remoteConfig.get<number>('port'),
+    host: remoteConfig.get<string>('host')
   };
 
   L.debug("getConfiguration", configuration);
@@ -57,7 +61,7 @@ const getConfiguration = () => {
 
 const hasConfigurationChanged = (configuration) => {
   L.trace('hasConfigurationChanged');
-  var hasChanged = configuration.port !== port || configuration.onStartup !== onStartup;
+  var hasChanged = configuration.port !== port || configuration.onStartup !== onStartup || configuration.host !== host;
 
   L.debug("hasConfigurationChanged?", hasChanged);
   return hasChanged;

--- a/src/lib/Server.ts
+++ b/src/lib/Server.ts
@@ -6,11 +6,13 @@ import Logger from '../utils/Logger';
 const L = Logger.getLogger('Server');
 
 const DEFAULT_PORT = 52698;
+const DEFAULT_HOST = '127.0.0.1';
 
 class Server {
   online : boolean = false;
   server : net.Server;
   port : number;
+  host : string;
   defaultSession : Session;
 
   start(quiet : boolean) {
@@ -34,7 +36,7 @@ class Server {
     this.server.on('error', this.onServerError.bind(this));
     this.server.on("close", this.onServerClose.bind(this));
 
-    this.server.listen(this.getPort(), '127.0.0.1');
+    this.server.listen(this.getPort(), this.getHost());
   }
 
   setPort(port : number) {
@@ -45,6 +47,16 @@ class Server {
   getPort() : number {
     L.trace('getPort', +(this.port || DEFAULT_PORT));
     return +(this.port || DEFAULT_PORT);
+  }
+
+  setHost(host : string) {
+    L.trace('setHost', host);
+    this.host = host;
+  }
+
+  getHost() : string {
+    L.trace('getHost', +(this.host || DEFAULT_HOST));
+    return (this.host || DEFAULT_HOST);
   }
 
   onServerConnection(socket) {


### PR DESCRIPTION
This change allows configuring what address the rmate daemon will listen on, instead of just localhost. 
For my own use, setting remote.host to my desktop local IP gives me the ability to remotely edit files on all machines within my LAN without worrying about forwarding ports and such. 

Note: the getLocalDirectoryName test fails for me, but I'm not sure if this is due to any changes I've done. 