### PR TITLE
Added squashlistenerror property

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ A package that implements the Textmate's 'rmate' feature for VSCode.
 
   // Launch the server on start up.
   "remote.onstartup": true
+
+  // Do not display errors when attempting to listen on remote.port.
+  "remote.squashlistenerror": false
   ```
 
 * Start the server in the command palette - Press F1 and type `Remote: Start server`, and press `ENTER` to start the server.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,11 @@
           "type": "string",
           "default": "127.0.0.1",
           "description": "Address to listen on."
+        },
+        "remote.squashlistenerror": {
+          "type": "boolean",
+          "default": false,
+          "description": "Do not show error when attempting to listen on specified port."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ var changeConfigurationDisposable : vscode.Disposable;
 var port : number;
 var host : string;
 var onStartup : boolean;
+var squashListenError : boolean;
 
 const startServer = () => {
   L.trace('startServer');
@@ -20,6 +21,7 @@ const startServer = () => {
 
   server.setPort(port);
   server.setHost(host);
+  server.setSquashListenError(squashListenError);
   server.start(false);
 };
 
@@ -50,6 +52,7 @@ const getConfiguration = () => {
 
   var configuration = {
     onStartup: remoteConfig.get<boolean>('onstartup'),
+    squashListenError: remoteConfig.get<boolean>('squashlistenerror'),
     port: remoteConfig.get<number>('port'),
     host: remoteConfig.get<string>('host')
   };

--- a/src/lib/Server.ts
+++ b/src/lib/Server.ts
@@ -13,6 +13,7 @@ class Server {
   server : net.Server;
   port : number;
   host : string;
+  squashListenError : boolean = false;
   defaultSession : Session;
 
   start(quiet : boolean) {
@@ -59,6 +60,11 @@ class Server {
     return (this.host || DEFAULT_HOST);
   }
 
+  setSquashListenError(squash : boolean) {
+    L.trace('setSquashListenError', squash);
+    this.squashListenError = squash;
+  }
+
   onServerConnection(socket) {
     L.trace('onServerConnection');
 
@@ -80,7 +86,11 @@ class Server {
     L.trace('onServerError', e);
 
     if (e.code == 'EADDRINUSE') {
-      return vscode.window.showErrorMessage(`Failed to start server, port ${e.port} already in use`);
+      if (this.squashListenError) {
+        return
+      } else {
+        return vscode.window.showErrorMessage(`Failed to start server, port ${e.port} already in use`);
+      }
     }
 
     vscode.window.showErrorMessage(`Failed to start server, will try again in 10 seconds}`);


### PR DESCRIPTION
I have no capability to test this code at the moment, but I believe that it will compile down to javascript and function as expected. 

The one thing I would have like to have done is to figure out if there is a way to communicate between editor windows so that once the first editor window opens the socket any new editor window would be able to determine that the socket is in use and to not give the error. Unfortunately, I have pretty much no knowledge of the programming environment for VS Code and was not able to find any examples that would give me an idea how it would work. 