### PR TITLE
Bring VSCode window to foreground after opening remote file

### DIFF
--- a/src/lib/Session.ts
+++ b/src/lib/Session.ts
@@ -4,6 +4,7 @@ import * as net from 'net';
 import Logger from '../utils/Logger';
 import Command from './Command';
 import RemoteFile from './RemoteFile';
+import {exec} from 'child_process';
 
 const L = Logger.getLogger('Session');
 
@@ -136,6 +137,7 @@ class Session extends EventEmitter {
         vscode.window.setStatusBarMessage(`Opening ${this.remoteFile.getRemoteBaseName()} from ${this.remoteFile.getHost()}`, 2000);
 
         this.showSelectedLine(textEditor);
+        exec("code");
       });
     });
   }


### PR DESCRIPTION
As a quick fix, this is (kinda hacky) done by launching VSCode via "code" by child_process.
This was inspired by the solution of a similar plugin for SublimeText (see https://github.com/randy3k/RemoteSubl/blob/f131b3b8b7317ac06998f96e1b8095c9841b2e1a/remote_subl.py#L140-L141).
